### PR TITLE
`OPEN_ALWAYS` -> `CREATE_ALWAYS` in `nob_fd_open_for_write`

### DIFF
--- a/nob.h
+++ b/nob.h
@@ -983,7 +983,7 @@ Nob_Fd nob_fd_open_for_write(const char *path)
                     GENERIC_WRITE,                   // open for writing
                     0,                               // do not share
                     &saAttr,                         // default security
-                    OPEN_ALWAYS,                     // open always
+                    CREATE_ALWAYS,                   // create always
                     FILE_ATTRIBUTE_NORMAL,           // normal file
                     NULL                             // no attr. template
                 );


### PR DESCRIPTION
Now `nob_fd_open_for_write` will clear the file before writing.

With `OPEN_ALWAYS` it would not clear the contents, leaving garbage data if new file size is less than old size.